### PR TITLE
Put TCL version number into interpreter call

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
+TCLTKVERSION=8.5
+
 # Compile OOMMF
 export OOMMF_TCL_CONFIG=${PREFIX}/lib/tclConfig.sh
 export OOMMF_TK_CONFIG=${PREFIX}/lib/tkConfig.sh
 cd oommf
-tclsh oommf.tcl pimake distclean
-tclsh oommf.tcl pimake upgrade
-tclsh oommf.tcl pimake
-tclsh oommf.tcl +platform
+tclsh${TCLTKVERSION} oommf.tcl pimake distclean
+tclsh${TCLTKVERSION} oommf.tcl pimake upgrade
+tclsh${TCLTKVERSION} oommf.tcl pimake
+tclsh${TCLTKVERSION} oommf.tcl +platform
 
 # Copy all OOMMF sources and compiled files into $PREFIX/opt/
 install -d ${PREFIX}/opt/
@@ -20,7 +22,7 @@ oommf_command=$(cat <<EOF
 #! /bin/bash
 export OOMMF_TCL_CONFIG=$PREFIX/lib/tclConfig.sh
 export OOMMF_TK_CONFIG=$PREFIX/lib/tkConfig.sh
-tclsh $PREFIX/opt/oommf/oommf.tcl "\$@"
+tclsh${TCLTKVERSION} $PREFIX/opt/oommf/oommf.tcl "\$@"
 EOF
 )
 echo "$oommf_command" > ${PREFIX}/bin/oommf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
    sha256: 98a0faa02dce17b6515401446e91622d29e64857d0a159ede8d5c44e1d4bca06  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win32]
 
 requirements:


### PR DESCRIPTION
Following discussion at https://github.com/conda-forge/staged-recipes/pull/3038#discussion_r118973407 , we change `tclsh` to `tclsh8.5`, to avoid the error arising from `tclsh` not being installed by conda.