### PR TITLE
Invoke tclsh by an absolute path rather than a command name

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,7 +22,7 @@ oommf_command=$(cat <<EOF
 #! /bin/bash
 export OOMMF_TCL_CONFIG=$PREFIX/lib/tclConfig.sh
 export OOMMF_TK_CONFIG=$PREFIX/lib/tkConfig.sh
-tclsh${TCLTKVERSION} $PREFIX/opt/oommf/oommf.tcl "\$@"
+$PREFIX/bin/tclsh${TCLTKVERSION} $PREFIX/opt/oommf/oommf.tcl "\$@"
 EOF
 )
 echo "$oommf_command" > ${PREFIX}/bin/oommf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
    sha256: 98a0faa02dce17b6515401446e91622d29e64857d0a159ede8d5c44e1d4bca06  # [win]
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win32]
 
 requirements:


### PR DESCRIPTION
This should make oommf work without activating the environment.