### PR TITLE
Another build with Windows patch.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
      - mmarchive.patch  # [win]
 
 build:
-  number: 4
+  number: 5
   skip: True  # [win32]
 
 requirements:


### PR DESCRIPTION
In the previous build 4, all checks passed, but after the merge MacOS and Windows build failed right in the beginning with

```
CondaHTTPError: HTTP 502 BAD GATEWAY for url <https://conda.anaconda.org/conda-forge/win
64/openssl-1.0.2o-vc9_0.tar.bz2>
Elapsed: 00:03.046739
CF-RAY: 432b8c72bc1d54fe-ORD
An HTTP error occurred when trying to retrieve this URL.
HTTP errors are often intermittent, and a simple retry will get you on your way.
```

Because there is no obvious way of restarting build, I make a new pull request with build number 5.